### PR TITLE
Add possibility to set custom text for N modifier instead ENY

### DIFF
--- a/web/js/src/armyc2/c2sd/renderer/SinglePointSVGRenderer.js
+++ b/web/js/src/armyc2/c2sd/renderer/SinglePointSVGRenderer.js
@@ -2217,7 +2217,7 @@ return{
         }
         
         //Check if we need to set 'N' to "ENY"
-        if(symbolID.charAt(1).toUpperCase()==="H")
+        if(symbolID.charAt(1).toUpperCase()==="H" && typeof modifiers[ModifiersTG.N_HOSTILE] !== 'string')
         {
             modifiers[ModifiersTG.N_HOSTILE] = "ENY";
         }


### PR DESCRIPTION
Hi, @michael-spinelli !
We use our product to visualize large sets of information about hostile units. Labeling ENY near each symbol creates visual noise and is unnecessary when using color displays. So I've added a small modifier check to create a possibility of setting an empty string into modifiers instead ENY label